### PR TITLE
vimeo対応

### DIFF
--- a/app/controllers/admin/talks_controller.rb
+++ b/app/controllers/admin/talks_controller.rb
@@ -52,9 +52,7 @@ class Admin::TalksController < ApplicationController
     )
 
     flash[:notice] = "OnAirに切り替えました: #{talk.start_to_end} #{talk.speaker_names.join(',')} #{talk.title}"
-    respond_to do |format|
-      format.js { render('admin/tracks/index.js') }
-    end
+    redirect_to admin_tracks_path
   end
 
   def stop_on_air
@@ -79,9 +77,7 @@ class Admin::TalksController < ApplicationController
     )
 
     flash[:notice] = "Waiting に切り替えました: #{talk.start_to_end} #{talk.speaker_names.join(',')} #{talk.title}"
-    respond_to do |format|
-      format.js { render('admin/tracks/index.js') }
-    end
+    redirect_to admin_tracks_path
   end
 
   def start_recording

--- a/app/controllers/admin/talks_controller.rb
+++ b/app/controllers/admin/talks_controller.rb
@@ -52,7 +52,7 @@ class Admin::TalksController < ApplicationController
     )
 
     flash[:notice] = "OnAirに切り替えました: #{talk.start_to_end} #{talk.speaker_names.join(',')} #{talk.title}"
-    redirect_to admin_tracks_path
+    redirect_to(admin_tracks_path)
   end
 
   def stop_on_air
@@ -77,7 +77,7 @@ class Admin::TalksController < ApplicationController
     )
 
     flash[:notice] = "Waiting に切り替えました: #{talk.start_to_end} #{talk.speaker_names.join(',')} #{talk.title}"
-    redirect_to admin_tracks_path
+    redirect_to(admin_tracks_path)
   end
 
   def start_recording

--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -54,7 +54,7 @@ class TalksController < ApplicationController
   end
 
   def display_video?(talk)
-    if (talk.conference.closed? && logged_in?) || (talk.conference.opened? && logged_in?) || talk.conference.archived?
+    if (talk.conference.closed? && logged_in?) || (talk.conference.opened? && logged_in?) || (talk.conference.video_enabled? && logged_in?) || talk.conference.archived?
       if talk.proposal_items.find_by(label: VideoAndSlidePublished::LABEL).present?
         if talk.proposal_items.empty?
           false

--- a/app/helpers/talks_helper.rb
+++ b/app/helpers/talks_helper.rb
@@ -14,6 +14,11 @@ module TalksHelper
       else
         video.on_air = false
       end
+      if value[:video_id].empty?
+        talk.video_published = false
+      else
+        talk.video_published = true
+      end
       video.save
     end
     ActionCable.server.broadcast(

--- a/app/models/talk.rb
+++ b/app/models/talk.rb
@@ -283,9 +283,7 @@ class Talk < ApplicationRecord
   end
 
   def archived?
-    now = Time.now.in_time_zone('Tokyo')
-    etime = DateTime.parse("#{conference_day.date.strftime('%Y-%m-%d')} #{end_time.strftime('%H:%M')} +0900")
-    (now.to_i - etime.to_i) >= 600
+    true
   end
 
   def sponsor_session?

--- a/app/views/admin/tracks/_tracks_nav.html.erb
+++ b/app/views/admin/tracks/_tracks_nav.html.erb
@@ -43,11 +43,21 @@
             <%=link_to "link", "https://player.vimeo.com/video/#{video_id}" %>
           <% end %>
         </td>
-        <td class="on_air_group btn-group-toggle">
+        <td >
           <% if talk.video %>
-            <label class="btn on_air_button <%= "active" if talk.video.on_air %>" id="button_<%= talk.id %>">
-              <input type="checkbox" name="video[<%= talk.id %>][on_air]" class="" <%= "checked" if talk.video.on_air %> autocomplete="off" track_name=<%= talk.track.name %>>
-            </label>
+            <%= form_with(url: on_air_url(talk), id: "talk_list_#{conference_day.date}_#{@track.number}", method: "post", class: "talk_list_form") do |f| %>
+              <%= f.hidden_field "talk[id]", value: talk.id %>
+              <div class="on_air_group btn-group-toggle">
+                <%= f.submit talk.video.on_air ? 'OnAir中' : 'Waiting',
+                             id: "button_#{talk.id}",
+                             class: "btn btn-#{talk.video.on_air? ? 'danger' : 'secondary'} on_air_button #{talk.video.on_air ? 'active' : ''}",
+                             autocomplete: "off",
+                             track_name: talk.track.name,
+                             talk_id: talk.id,
+                             data: { confirm: confirm_message(talk) }
+                %>
+              </div>
+            <% end %>
           <% end %>
         </td>
       </tr>

--- a/db/fixtures/development/00_seeds.rb
+++ b/db/fixtures/development/00_seeds.rb
@@ -31,11 +31,11 @@ ConferenceDay.seed(
 )
 
 Track.seed(
-  { id: 1,  conference_id: 1, name: "大規模システム運用"},
-  { id: 2,  conference_id: 1, name: "運用苦労話（しくじり、トラシュー）"},
-  { id: 3,  conference_id: 1, name: "運用自動化（Dev/Ops、CI/CD）"},
-  { id: 4,  conference_id: 1, name: "社内基盤（情シス、開発環境）"},
-  { id: 5,  conference_id: 1, name: "サービス・アプリケーション運用"},
-  { id: 6,  conference_id: 1, name: "製品・技術トレンド"},
-  { id: 7,  conference_id: 1, name: "Cloud CoE"},
+  { id: 1,  conference_id: 1, number: 1, name: "大規模システム運用"},
+  { id: 2,  conference_id: 1, number: 2, name: "運用苦労話（しくじり、トラシュー）"},
+  { id: 3,  conference_id: 1, number: 3, name: "運用自動化（Dev/Ops、CI/CD）"},
+  { id: 4,  conference_id: 1, number: 4, name: "社内基盤（情シス、開発環境）"},
+  { id: 5,  conference_id: 1, number: 5, name: "サービス・アプリケーション運用"},
+  { id: 6,  conference_id: 1, number: 6, name: "製品・技術トレンド"},
+  { id: 7,  conference_id: 1, number: 7, name: "Cloud CoE"},
 )

--- a/db/fixtures/production/00_seeds.rb
+++ b/db/fixtures/production/00_seeds.rb
@@ -31,11 +31,11 @@ ConferenceDay.seed(
 )
 
 Track.seed(
-  { id: 1,  conference_id: 1, name: "大規模システム運用"},
-  { id: 2,  conference_id: 1, name: "運用苦労話（しくじり、トラシュー）"},
-  { id: 3,  conference_id: 1, name: "運用自動化（Dev/Ops、CI/CD）"},
-  { id: 4,  conference_id: 1, name: "社内基盤（情シス、開発環境）"},
-  { id: 5,  conference_id: 1, name: "サービス・アプリケーション運用"},
-  { id: 6,  conference_id: 1, name: "製品・技術トレンド"},
-  { id: 7,  conference_id: 1, name: "Cloud CoE"},
+  { id: 1,  conference_id: 1, number: 1, name: "大規模システム運用"},
+  { id: 2,  conference_id: 1, number: 2, name: "運用苦労話（しくじり、トラシュー）"},
+  { id: 3,  conference_id: 1, number: 3, name: "運用自動化（Dev/Ops、CI/CD）"},
+  { id: 4,  conference_id: 1, number: 4, name: "社内基盤（情シス、開発環境）"},
+  { id: 5,  conference_id: 1, number: 5, name: "サービス・アプリケーション運用"},
+  { id: 6,  conference_id: 1, number: 6, name: "製品・技術トレンド"},
+  { id: 7,  conference_id: 1, number: 7, name: "Cloud CoE"},
 )

--- a/spec/controllers/talks_controller/display_video_spec.rb
+++ b/spec/controllers/talks_controller/display_video_spec.rb
@@ -175,6 +175,20 @@ RSpec.describe(TalksController, type: :controller) do
         it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_video, true
         it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ng, false
       end
+
+      context 'conference is video_enabled' do
+        let!(:conference) { create(:codt2022, :video_enabled) }
+
+        it_should_behave_like :video_is_published_and_present_and_archived, true
+        it_should_behave_like :video_is_not_published, false
+        it_should_behave_like :video_is_not_present, false
+        it_should_behave_like :video_is_not_archived, false
+
+        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ok, true
+        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_slide, false
+        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_video, true
+        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ng, false
+      end
     end
 
     context "user doesn't logged in" do
@@ -235,6 +249,20 @@ RSpec.describe(TalksController, type: :controller) do
         it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ok, true
         it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_slide, false
         it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_video, true
+        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ng, false
+      end
+
+      context 'conference is video_enabled' do
+        let!(:conference) { create(:codt2022, :video_enabled) }
+
+        it_should_behave_like :video_is_published_and_present_and_archived, false
+        it_should_behave_like :video_is_not_published, false
+        it_should_behave_like :video_is_not_present, false
+        it_should_behave_like :video_is_not_archived, false
+
+        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ok, false
+        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_slide, false
+        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_video, false
         it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ng, false
       end
     end

--- a/spec/factories/conferences.rb
+++ b/spec/factories/conferences.rb
@@ -68,6 +68,11 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
       speaker_entry { 0 }
     end
 
+    trait :video_enabled do
+      status { 4 }
+      speaker_entry { 0 }
+    end
+
     trait :speaker_entry_enabled do
       speaker_entry { 1 }
     end


### PR DESCRIPTION
- Conferenceのstatusがvideo_enabled、かつVideoのvideo_idにvimeoのidが入っている場合、ログインすればtalk/#id上でアーカイブ動画を見られるようにする
- 今回はセッションの終了時以降見えるようにする必要はないので、Talkのarchived?メソッドは常にtrueを返す