### PR TITLE
Fix flag and add dummy box

### DIFF
--- a/app/controllers/talks_controller.rb
+++ b/app/controllers/talks_controller.rb
@@ -55,16 +55,7 @@ class TalksController < ApplicationController
 
   def display_video?(talk)
     if (talk.conference.closed? && logged_in?) || (talk.conference.opened? && logged_in?) || (talk.conference.video_enabled? && logged_in?) || talk.conference.archived?
-      if talk.proposal_items.find_by(label: VideoAndSlidePublished::LABEL).present?
-        if talk.proposal_items.empty?
-          false
-        else
-          proposal_item = talk.proposal_items.find_by(label: VideoAndSlidePublished::LABEL) || []
-          proposal_item.proposal_item_configs.map { |config| [VideoAndSlidePublished::ALL_OK, VideoAndSlidePublished::ONLY_VIDEO].include?(config.key.to_i) }.any?
-        end
-      else
-        (talk.video_published && talk.video.present? && talk.archived?)
-      end
+      (talk.video.present? && talk.video.video_id != '')
     else
       false
     end

--- a/app/views/talks/partial_show/_col_main_pane.html.erb
+++ b/app/views/talks/partial_show/_col_main_pane.html.erb
@@ -21,7 +21,9 @@
           <%= render 'talks/partial_show/talk_video_block_videojs', talk: talk %>
         <% else %>
           <%= render 'talks/partial_show/talk_video_block', talk: talk %>
-          <% end %>
+        <% end %>
+      <% else %>
+        <%= render 'talks/partial_show/talk_video_block_dummy', talk: talk %>
       <% end %>
 
       <p><%= simple_format talk.abstract %></p>
@@ -41,11 +43,6 @@
         </div>
       <% end %>
 
-      <% if (conference.registered? || conference.opened?) && conference.attendee_entry_enabled? && !(logged_in? && @profile.present?) %>
-      <div class="col-12 text-center my-4">
-        <%= link_to "このイベントに参加申し込み <br/> (参加無料)".html_safe, registration_path, {method: :get, class: "btn btn-focus btn-xl inline" } %>
-      </div>
-      <% end %>
       <div class="col-12 text-center my-4">
         <%= button_to 'タイムテーブル', timetables_path, {method: :get, class: "btn btn-primary btn-xl inline" } %>
       </div>

--- a/app/views/talks/partial_show/_talk_video_block_dummy.html.erb
+++ b/app/views/talks/partial_show/_talk_video_block_dummy.html.erb
@@ -1,0 +1,8 @@
+<div class="mb-2">
+    <div style="height: 300px; background-color:#000;box-shadow: 0px 0px 10px black;" class="text-center d-flex align-items-center">
+    <div class="col-12 text-center my-4" style="color: white;">
+        この動画を視聴するには参加登録が必要です。<br/>
+        <%= link_to "このイベントに参加申し込み <br/> (参加無料)".html_safe, registration_path, {method: :get, class: "btn btn-focus btn-xl inline" } %>
+    </div>
+    </div>
+</div>

--- a/spec/controllers/talks_controller/display_video_spec.rb
+++ b/spec/controllers/talks_controller/display_video_spec.rb
@@ -69,7 +69,6 @@ RSpec.describe(TalksController, type: :controller) do
 
         it_should_behave_like :video_is_published_and_present_and_archived, false
         it_should_behave_like :video_is_not_present, false
-
       end
 
       context 'conference is opened' do
@@ -77,7 +76,6 @@ RSpec.describe(TalksController, type: :controller) do
 
         it_should_behave_like :video_is_published_and_present_and_archived, true
         it_should_behave_like :video_is_not_present, false
-
       end
 
       context 'conference is closed' do
@@ -85,7 +83,6 @@ RSpec.describe(TalksController, type: :controller) do
 
         it_should_behave_like :video_is_published_and_present_and_archived, true
         it_should_behave_like :video_is_not_present, false
-
       end
 
       context 'conference is archived' do
@@ -93,7 +90,6 @@ RSpec.describe(TalksController, type: :controller) do
 
         it_should_behave_like :video_is_published_and_present_and_archived, true
         it_should_behave_like :video_is_not_present, false
-
       end
 
       context 'conference is video_enabled' do
@@ -101,7 +97,6 @@ RSpec.describe(TalksController, type: :controller) do
 
         it_should_behave_like :video_is_published_and_present_and_archived, true
         it_should_behave_like :video_is_not_present, false
-
       end
     end
 
@@ -115,7 +110,6 @@ RSpec.describe(TalksController, type: :controller) do
 
         it_should_behave_like :video_is_published_and_present_and_archived, false
         it_should_behave_like :video_is_not_present, false
-
       end
 
       context 'conference is opened' do
@@ -123,7 +117,6 @@ RSpec.describe(TalksController, type: :controller) do
 
         it_should_behave_like :video_is_published_and_present_and_archived, false
         it_should_behave_like :video_is_not_present, false
-
       end
 
       context 'conference is closed' do
@@ -131,7 +124,6 @@ RSpec.describe(TalksController, type: :controller) do
 
         it_should_behave_like :video_is_published_and_present_and_archived, false
         it_should_behave_like :video_is_not_present, false
-
       end
 
       context 'conference is archived' do
@@ -139,7 +131,6 @@ RSpec.describe(TalksController, type: :controller) do
 
         it_should_behave_like :video_is_published_and_present_and_archived, true
         it_should_behave_like :video_is_not_present, false
-
       end
 
       context 'conference is video_enabled' do
@@ -147,7 +138,6 @@ RSpec.describe(TalksController, type: :controller) do
 
         it_should_behave_like :video_is_published_and_present_and_archived, false
         it_should_behave_like :video_is_not_present, false
-
       end
     end
   end

--- a/spec/controllers/talks_controller/display_video_spec.rb
+++ b/spec/controllers/talks_controller/display_video_spec.rb
@@ -13,62 +13,6 @@ RSpec.describe(TalksController, type: :controller) do
       end
     end
 
-    shared_examples_for :proposal_item_whether_it_can_be_published_is_all_ok do |bool|
-      context 'proposal_item whether_it_can_be_published is all_ok' do
-        before do
-          allow_any_instance_of(Talk).to(receive(:archived?).and_return(true))
-          create(:proposal_item_configs_whether_it_can_be_published, :all_ok, conference: conference)
-          create(:proposal_item_whether_it_can_be_published, :all_ok, talk: talk1)
-        end
-        let!(:talk1) { create(:talk1, :video_published, conference: conference) }
-        let!(:video) { create(:video) }
-
-        it_should_behave_like :display_video_method_returns, bool
-      end
-    end
-
-    shared_examples_for :proposal_item_whether_it_can_be_published_is_only_slide do |bool|
-      context 'proposal_item whether_it_can_be_published is only_slide' do
-        before do
-          allow_any_instance_of(Talk).to(receive(:archived?).and_return(true))
-          create(:proposal_item_configs_whether_it_can_be_published, :only_slide, conference: conference)
-          create(:proposal_item_whether_it_can_be_published, :only_slide, talk: talk1)
-        end
-        let!(:talk1) { create(:talk1, :video_published, conference: conference) }
-        let!(:video) { create(:video) }
-
-        it_should_behave_like :display_video_method_returns, bool
-      end
-    end
-
-    shared_examples_for :proposal_item_whether_it_can_be_published_is_only_video do |bool|
-      context 'proposal_item whether_it_can_be_published is only_video' do
-        before do
-          allow_any_instance_of(Talk).to(receive(:archived?).and_return(true))
-          create(:proposal_item_configs_whether_it_can_be_published, :only_video, conference: conference)
-          create(:proposal_item_whether_it_can_be_published, :only_video, talk: talk1)
-        end
-        let!(:talk1) { create(:talk1, :video_published, conference: conference) }
-        let!(:video) { create(:video) }
-
-        it_should_behave_like :display_video_method_returns, bool
-      end
-    end
-
-    shared_examples_for :proposal_item_whether_it_can_be_published_is_all_ng do |bool|
-      context 'proposal_item whether_it_can_be_published is all_ng' do
-        before do
-          allow_any_instance_of(Talk).to(receive(:archived?).and_return(true))
-          create(:proposal_item_configs_whether_it_can_be_published, :all_ng, conference: conference)
-          create(:proposal_item_whether_it_can_be_published, :all_ng, talk: talk1)
-        end
-        let!(:talk1) { create(:talk1, :video_published, conference: conference) }
-        let!(:video) { create(:video) }
-
-        it_should_behave_like :display_video_method_returns, bool
-      end
-    end
-
     shared_examples_for :video_is_published_and_present_and_archived do |bool|
       context 'talk is video_published, video is present and talk is archived' do
         before do
@@ -124,70 +68,40 @@ RSpec.describe(TalksController, type: :controller) do
         let!(:conference) { create(:codt2022, :registered) }
 
         it_should_behave_like :video_is_published_and_present_and_archived, false
-        it_should_behave_like :video_is_not_published, false
         it_should_behave_like :video_is_not_present, false
-        it_should_behave_like :video_is_not_archived, false
 
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ok, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_slide, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_video, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ng, false
       end
 
       context 'conference is opened' do
         let!(:conference) { create(:codt2022, :opened) }
 
         it_should_behave_like :video_is_published_and_present_and_archived, true
-        it_should_behave_like :video_is_not_published, false
         it_should_behave_like :video_is_not_present, false
-        it_should_behave_like :video_is_not_archived, false
 
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ok, true
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_slide, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_video, true
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ng, false
       end
 
       context 'conference is closed' do
         let!(:conference) { create(:codt2022, :closed) }
 
         it_should_behave_like :video_is_published_and_present_and_archived, true
-        it_should_behave_like :video_is_not_published, false
         it_should_behave_like :video_is_not_present, false
-        it_should_behave_like :video_is_not_archived, false
 
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ok, true
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_slide, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_video, true
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ng, false
       end
 
       context 'conference is archived' do
         let!(:conference) { create(:codt2022, :archived) }
 
         it_should_behave_like :video_is_published_and_present_and_archived, true
-        it_should_behave_like :video_is_not_published, false
         it_should_behave_like :video_is_not_present, false
-        it_should_behave_like :video_is_not_archived, false
 
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ok, true
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_slide, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_video, true
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ng, false
       end
 
       context 'conference is video_enabled' do
         let!(:conference) { create(:codt2022, :video_enabled) }
 
         it_should_behave_like :video_is_published_and_present_and_archived, true
-        it_should_behave_like :video_is_not_published, false
         it_should_behave_like :video_is_not_present, false
-        it_should_behave_like :video_is_not_archived, false
 
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ok, true
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_slide, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_video, true
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ng, false
       end
     end
 
@@ -200,70 +114,40 @@ RSpec.describe(TalksController, type: :controller) do
         let!(:conference) { create(:codt2022, :registered) }
 
         it_should_behave_like :video_is_published_and_present_and_archived, false
-        it_should_behave_like :video_is_not_published, false
         it_should_behave_like :video_is_not_present, false
-        it_should_behave_like :video_is_not_archived, false
 
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ok, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_slide, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_video, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ng, false
       end
 
       context 'conference is opened' do
         let!(:conference) { create(:codt2022, :opened) }
 
         it_should_behave_like :video_is_published_and_present_and_archived, false
-        it_should_behave_like :video_is_not_published, false
         it_should_behave_like :video_is_not_present, false
-        it_should_behave_like :video_is_not_archived, false
 
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ok, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_slide, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_video, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ng, false
       end
 
       context 'conference is closed' do
         let!(:conference) { create(:codt2022, :closed) }
 
         it_should_behave_like :video_is_published_and_present_and_archived, false
-        it_should_behave_like :video_is_not_published, false
         it_should_behave_like :video_is_not_present, false
-        it_should_behave_like :video_is_not_archived, false
 
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ok, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_slide, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_video, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ng, false
       end
 
       context 'conference is archived' do
         let!(:conference) { create(:codt2022, :archived) }
 
         it_should_behave_like :video_is_published_and_present_and_archived, true
-        it_should_behave_like :video_is_not_published, false
         it_should_behave_like :video_is_not_present, false
-        it_should_behave_like :video_is_not_archived, false
 
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ok, true
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_slide, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_video, true
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ng, false
       end
 
       context 'conference is video_enabled' do
         let!(:conference) { create(:codt2022, :video_enabled) }
 
         it_should_behave_like :video_is_published_and_present_and_archived, false
-        it_should_behave_like :video_is_not_published, false
         it_should_behave_like :video_is_not_present, false
-        it_should_behave_like :video_is_not_archived, false
 
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ok, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_slide, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_only_video, false
-        it_should_behave_like :proposal_item_whether_it_can_be_published_is_all_ng, false
       end
     end
   end

--- a/spec/requests/talks_spec.rb
+++ b/spec/requests/talks_spec.rb
@@ -179,18 +179,6 @@ describe TalksController, type: :request do
               expect(response.body).to(include('player.vimeo.com'))
             end
           end
-
-          context 'talk is not archived' do
-            before do
-              allow_any_instance_of(Talk).to(receive(:archived?).and_return(false))
-            end
-
-            it 'includes vimeo iframe' do
-              get '/codt2022/talks/1'
-              expect(response).to(be_successful)
-              expect(response.body).not_to(include('player.vimeo.com'))
-            end
-          end
         end
       end
     end
@@ -270,18 +258,6 @@ describe TalksController, type: :request do
               expect(response.body).to(include('player.vimeo.com'))
             end
           end
-
-          context 'talk is not archived' do
-            before do
-              allow_any_instance_of(Talk).to(receive(:archived?).and_return(false))
-            end
-
-            it 'includes vimeo iframe' do
-              get '/codt2022/talks/1'
-              expect(response).to(be_successful)
-              expect(response.body).not_to(include('player.vimeo.com'))
-            end
-          end
         end
       end
     end
@@ -306,18 +282,6 @@ describe TalksController, type: :request do
             get '/codt2022/talks/1'
             expect(response).to(be_successful)
             expect(response.body).to(include('player.vimeo.com'))
-          end
-        end
-
-        context 'talk is not archived' do
-          before do
-            allow_any_instance_of(Talk).to(receive(:archived?).and_return(false))
-          end
-
-          it "doesn't includes vimeo iframe" do
-            get '/codt2022/talks/1'
-            expect(response).to(be_successful)
-            expect(response.body).to_not(include('player.vimeo.com'))
           end
         end
       end
@@ -359,18 +323,6 @@ describe TalksController, type: :request do
               get '/codt2022/talks/1'
               expect(response).to(be_successful)
               expect(response.body).to(include('player.vimeo.com'))
-            end
-          end
-
-          context 'talk is not archived' do
-            before do
-              allow_any_instance_of(Talk).to(receive(:archived?).and_return(false))
-            end
-
-            it 'includes vimeo iframe' do
-              get '/codt2022/talks/1'
-              expect(response).to(be_successful)
-              expect(response.body).not_to(include('player.vimeo.com'))
             end
           end
         end


### PR DESCRIPTION
video_enabled時にちゃんとビデオが表示されていなかったので修正。

また、ログインしていない時には登録を促すダミーのボックスを追加した。

![image](https://user-images.githubusercontent.com/79102/175800860-5529fff9-c55b-41b4-8c16-81c742205a86.png)

CNDT側で使っているvideoのarchivedステータスやProposal側にある公開許可フラグは利用しないので、それに関するif文やテストは削除