### PR TITLE
ダッシュボードからセッションを表示したときにアンケートが出ないパターンがある件の修正

### DIFF
--- a/app/views/tracks/waiting.html.erb
+++ b/app/views/tracks/waiting.html.erb
@@ -33,7 +33,7 @@
         <div id="registered-talk-list" class="row">
           <% @profile.talks.each do |talk| %>
             <div class="col-12 col-lg-3 col-md-4 card-column py-3">
-              <a href="<%= talk_path(id: talk.id) %>">
+              <a href="<%= talk_path(id: talk.id) %>" data-turbolinks="false" >
               <div class="card registered-talk-card">
                 <div class="avatar">
                   <% unless talk.speakers[0].blank? %>


### PR DESCRIPTION
Slackで連絡のあったこちらの件への対処

```
Chrome環境でセッション視聴中に、アンケートポップアップが表示されない事象がありました。以下再現方法です。
・ログイン後のトップ画面で、自分が登録したセッションのリストからクリックして視聴する（ここはアンケートが表示）
・視聴後、アンケートに回答し、アンケート画面を閉じる。
・ブラウザの戻るボタンで、トップページに戻る
・別のセッションをクリックして視聴
・このセッションのアンケートが表示されない★
・ブラウザをリロードして視聴するとちゃんと表示される。
```

まだ原因が完全に特定出来たわけでは無いが、挙動的にTurbolinksが怪しい感じ。
セッションリストにはTurbolinksの無効化が含まれているがダッシュボードからのリンクにはなかったため、こちらも追加した